### PR TITLE
chore: update Dockerfile to use ARG for whisper.cpp version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+ARG WHISPER_CPP_VERSION="v1.7.6"
+
 # Multi-stage build for whisper.wasm
 FROM emscripten/emsdk:4.0.14 AS builder
 
@@ -12,7 +14,8 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Clone whisper.cpp repository
-RUN git clone https://github.com/ggerganov/whisper.cpp.git
+ARG WHISPER_CPP_VERSION
+RUN git clone --depth 1 --branch $WHISPER_CPP_VERSION https://github.com/ggml-org/whisper.cpp.git
 
 WORKDIR /src/whisper.cpp
 RUN mkdir build-em


### PR DESCRIPTION
- Added an ARG for WHISPER_CPP_VERSION to specify the version of whisper.cpp during the build.
- Updated the git clone command to use the specified branch from the repository.